### PR TITLE
Fix a error from generate uuid string

### DIFF
--- a/client.go
+++ b/client.go
@@ -115,9 +115,10 @@ type client struct {
 
 // newClient creates new client connection.
 func newClient(ctx context.Context, n *Node, t transport) *client {
+	uuid, _ := uuid.NewV4()
 	c := &client{
 		ctx:       ctx,
-		uid:       uuid.NewV4().String(),
+		uid:       uuid.String(),
 		node:      n,
 		transport: t,
 	}

--- a/client.go
+++ b/client.go
@@ -115,10 +115,10 @@ type client struct {
 
 // newClient creates new client connection.
 func newClient(ctx context.Context, n *Node, t transport) *client {
-	uuid, _ := uuid.NewV4()
+	uuidObject, _ := uuid.NewV4()
 	c := &client{
 		ctx:       ctx,
-		uid:       uuid.String(),
+		uid:       uuidObject.String(),
 		node:      n,
 		transport: t,
 	}

--- a/node.go
+++ b/node.go
@@ -59,7 +59,8 @@ type Node struct {
 
 // New creates Node, the only required argument is config.
 func New(c Config) *Node {
-	uid := uuid.NewV4().String()
+	uidObject, _ := uuid.NewV4()
+	uid := uidObject.String()
 
 	n := &Node{
 		uid:            uid,


### PR DESCRIPTION
fix a error : client.go:118:23: multiple-value uuid.NewV4() in single-value context